### PR TITLE
Fixed Quit Stacking Error

### DIFF
--- a/blackjack-ai/main_menu.py
+++ b/blackjack-ai/main_menu.py
@@ -113,10 +113,10 @@ def main_menu():
                         player_blackjack.run() 
                 if black_Jack2.checkForInput(MENU_MOUSE_POS):
                     if observe_mode() :
-                        player_blackjack_spanish = PlayerSpanishBlackjack(SCREEN)
+                        player_blackjack_spanish = PlayerSpanishBlackjack(True, SCREEN, q_table=q_table)
                         player_blackjack_spanish.run()
                     else :
-                        player_blackjack_spanish = PlayerSpanishBlackjack(SCREEN)
+                        player_blackjack_spanish = PlayerSpanishBlackjack(False, SCREEN, q_table=q_table)
                         player_blackjack_spanish.run()
                 if black_Jack3.checkForInput(MENU_MOUSE_POS):  # New logic for Blackjack Switch
                     if observe_mode() :
@@ -127,10 +127,10 @@ def main_menu():
                         player_blackjack_switch.run()
                 if black_Jack4.checkForInput(MENU_MOUSE_POS):  # New logic for Blackjack Switch
                     if observe_mode() :
-                        player_blackjack_european = PlayerEBlackjack(SCREEN)
+                        player_blackjack_european = PlayerEBlackjack(True, SCREEN, q_table=q_table)
                         player_blackjack_european.run()
                     else : 
-                        player_blackjack_european = PlayerEBlackjack(SCREEN)
+                        player_blackjack_european = PlayerEBlackjack(False, SCREEN, q_table=q_table)
                         player_blackjack_european.run()
                 if QUIT_BUTTON.checkForInput(MENU_MOUSE_POS):
                     pygame.quit()

--- a/blackjack-ai/main_menu.py
+++ b/blackjack-ai/main_menu.py
@@ -113,10 +113,10 @@ def main_menu():
                         player_blackjack.run() 
                 if black_Jack2.checkForInput(MENU_MOUSE_POS):
                     if observe_mode() :
-                        player_blackjack_spanish = PlayerSpanishBlackjack(True, SCREEN, q_table=q_table)
+                        player_blackjack_spanish = PlayerSpanishBlackjack(SCREEN)
                         player_blackjack_spanish.run()
                     else :
-                        player_blackjack_spanish = PlayerSpanishBlackjack(False, SCREEN, q_table=q_table)
+                        player_blackjack_spanish = PlayerSpanishBlackjack(SCREEN)
                         player_blackjack_spanish.run()
                 if black_Jack3.checkForInput(MENU_MOUSE_POS):  # New logic for Blackjack Switch
                     if observe_mode() :
@@ -127,10 +127,10 @@ def main_menu():
                         player_blackjack_switch.run()
                 if black_Jack4.checkForInput(MENU_MOUSE_POS):  # New logic for Blackjack Switch
                     if observe_mode() :
-                        player_blackjack_european = PlayerEBlackjack(True, SCREEN, q_table=q_table)
+                        player_blackjack_european = PlayerEBlackjack(SCREEN)
                         player_blackjack_european.run()
                     else : 
-                        player_blackjack_european = PlayerEBlackjack(False, SCREEN, q_table=q_table)
+                        player_blackjack_european = PlayerEBlackjack(SCREEN)
                         player_blackjack_european.run()
                 if QUIT_BUTTON.checkForInput(MENU_MOUSE_POS):
                     pygame.quit()

--- a/blackjack-ai/player/player_game1.py
+++ b/blackjack-ai/player/player_game1.py
@@ -143,6 +143,7 @@ class PlayerBlackjack:
         # Display result if screen is available
         pygame.display.flip()
         running = True
+        restart = False
         while running:
             if self.screen:
                 for event in pygame.event.get():
@@ -152,9 +153,11 @@ class PlayerBlackjack:
                         if event.button == 1:  # Left mouse button
                             if self.button_restart.collidepoint(event.pos):
                                 self.show_hand = False
-                                self.run()
+                                restart = True
+                                running = False
                             elif self.button_quit.collidepoint(event.pos):
                                 running = False
+        if restart: self.run()
 
     def get_key_action(self, event, state):
         """Return 'Hit', 'Double', or 'Stand' based on player input or policy."""

--- a/blackjack-ai/player/player_game2.py
+++ b/blackjack-ai/player/player_game2.py
@@ -145,6 +145,7 @@ class PlayerSpanishBlackjack:
         # Display result if screen is available
         pygame.display.flip()
         running = True
+        restart = False
         while running:
             if self.screen:
                 for event in pygame.event.get():
@@ -154,9 +155,11 @@ class PlayerSpanishBlackjack:
                         if event.button == 1:  # Left mouse button
                             if self.button_restart.collidepoint(event.pos):
                                 self.show_hand = False
-                                self.run()
+                                restart = True
+                                running = False
                             elif self.button_quit.collidepoint(event.pos):
                                 running = False
+        if restart: self.run()
 
     def get_key_action(self, event, state):
         """Return 'Hit', 'Double', or 'Stand' based on player input or policy."""

--- a/blackjack-ai/player/player_game3.py
+++ b/blackjack-ai/player/player_game3.py
@@ -77,6 +77,7 @@ class PlayerBlackjackSwitch:
         # Display result if screen is available
         pygame.display.flip()
         running = True
+        restart = False
         while running:
             if self.screen:
                 for event in pygame.event.get():
@@ -86,10 +87,11 @@ class PlayerBlackjackSwitch:
                         if event.button == 1:  # Left mouse button
                             if self.button_restart.collidepoint(event.pos):
                                 self.show_hand = False
-                                self.run()
+                                restart = True
+                                running = False
                             elif self.button_quit.collidepoint(event.pos):
                                 running = False
-
+        if restart: self.run()
     def get_player_action(self):
         """Return 'Switch', 'Hit Hand 1', 'Hit Hand 2', 'Double Hand 1', 'Double Hand 2', or 'Stand' based on player input or policy."""
         if self.screen:

--- a/blackjack-ai/player/player_game4.py
+++ b/blackjack-ai/player/player_game4.py
@@ -143,6 +143,7 @@ class PlayerEBlackjack:
         # Display result if screen is available
         pygame.display.flip()
         running = True
+        restart = False
         while running:
             if self.screen:
                 for event in pygame.event.get():
@@ -152,9 +153,11 @@ class PlayerEBlackjack:
                         if event.button == 1:  # Left mouse button
                             if self.button_restart.collidepoint(event.pos):
                                 self.show_hand = False
-                                self.run()
+                                restart = True
+                                running = False
                             elif self.button_quit.collidepoint(event.pos):
                                 running = False
+        if restart: self.run()
 
     def get_key_action(self, event, state):
         """Return 'Hit', 'Double', or 'Stand' based on player input or policy."""


### PR DESCRIPTION
As it turns out, whenever you restart the game,
you enter a nested loop inside the already existing game loop, so you have to click quit multiple times to end the game if you've been playing multiple games.

Moved self.run() out of the screen loop to fix.